### PR TITLE
[Title] Namespace 정보도 추출할 수 있게 변경

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -57,9 +57,10 @@ LIST( APPEND SOURCE_DIR
     ${PROPERTYREFLECTION_DIR}/PropertyInfo.h
 
     ${TYPEREFLECTION_DIR}/TypeMacro.h
-    ${TYPEREFLECTION_DIR}/TypeInfo.h ${TYPEREFLECTION_DIR}/TypeInfo.cpp
     ${TYPEREFLECTION_DIR}/TypeCast.h
-    ${TYPEREFLECTION_DIR}/TypeUtils.h
+    ${TYPEREFLECTION_DIR}/TypeUtils.h ${TYPEREFLECTION_DIR}/TypeUtils.cpp
+    ${TYPEREFLECTION_DIR}/TypeInfo.h ${TYPEREFLECTION_DIR}/TypeInfo.cpp
+    ${TYPEREFLECTION_DIR}/TypeManager.h ${TYPEREFLECTION_DIR}/TypeManager.cpp
     )
 
 IF ( WIN32 )

--- a/TypeReflection/TypeInfo.cpp
+++ b/TypeReflection/TypeInfo.cpp
@@ -2,24 +2,24 @@
 
 namespace MetaData
 {
-    TypeInfo::TypeInfo(const char* _pName, const TypeInfo* _pSuper)
-        : m_pTypeName(_pName)
+    TypeInfo::TypeInfo(const std::string& _strName, const TypeInfo* _pSuper)
+        : m_strTypeName(_strName)
         , m_pSuper(_pSuper)
     {}
 
     TypeInfo::TypeInfo(const TypeInfo& _rhs)
-        : m_pTypeName(_rhs.m_pTypeName)
+        : m_strTypeName(_rhs.m_strTypeName)
         , m_pSuper(_rhs.m_pSuper)
     {}
 
     TypeInfo::TypeInfo(TypeInfo&& _rhs)
-        : m_pTypeName(_rhs.m_pTypeName)
+        : m_strTypeName(_rhs.m_strTypeName)
         , m_pSuper(_rhs.m_pSuper)
     {}
 
     bool TypeInfo::operator==(const TypeInfo& _rhs) const
     {
-        if ((m_pTypeName == _rhs.m_pTypeName) || (m_pSuper == _rhs.m_pSuper))
+        if ((m_strTypeName == _rhs.m_strTypeName) || (m_pSuper == _rhs.m_pSuper))
         {
             return true;
         }
@@ -39,8 +39,8 @@ namespace MetaData
         return m_pSuper;
     }
 
-    const char* TypeInfo::GetTypeName() const
+    const std::string& TypeInfo::GetTypeName() const
     {
-        return m_pTypeName;
+        return m_strTypeName;
     }
 }

--- a/TypeReflection/TypeInfo.h
+++ b/TypeReflection/TypeInfo.h
@@ -1,13 +1,15 @@
 #ifndef __TYPE_INFO_H__
 #define __TYPE_INFO_H__
 
+#include <string>
+
 namespace MetaData
 {
 	class TypeInfo
 	{
 		public :
 			TypeInfo() = delete;
-			explicit TypeInfo(const char* _pName, const TypeInfo* _pSuper = nullptr);
+			explicit TypeInfo(const std::string& _strName, const TypeInfo* _pSuper = nullptr);
 			TypeInfo(const TypeInfo& _rhs);
 			TypeInfo(TypeInfo&& _rhs);
 
@@ -17,10 +19,10 @@ namespace MetaData
 			void SetSuper(const TypeInfo*  _pSuper);
 
 			const TypeInfo* GetSuper() const;
-			const char* GetTypeName() const;
+			const std::string& GetTypeName() const;
 
 		private :
-			const char* m_pTypeName;
+			const std::string m_strTypeName;
 			const TypeInfo* m_pSuper;
 	};
 };

--- a/TypeReflection/TypeMacro.h
+++ b/TypeReflection/TypeMacro.h
@@ -3,6 +3,14 @@
 
 #include "TypeUtils.h"
 
+#if defined(_MSC_VER)
+	#define FUNCSIG __FUNCSIG__
+#elif defined(__GNUC__) || defined(__clang__)
+	#define FUNCSIG __PRETTY_FUNCTION__
+#else
+	#define FUNCSIG __func__
+#endif
+
 #define GENERATE( className ) \
     private : \
         friend Type::Utils::SuperTypeDetection; \
@@ -13,7 +21,7 @@
 \
         static const MetaData::TypeInfo* GetStaticTypeInfo() \
         { \
-            static MetaData::TypeInfo typeinfo(Type::Utils::TypeInitializer<SuperType>::Init(#className)); \
+            static MetaData::TypeInfo typeinfo(Type::Utils::TypeInitializer<SuperType>::Init(Type::Utils::ConvertToType(FUNCSIG))); \
             return &typeinfo; \
         } \
 \

--- a/TypeReflection/TypeManager.cpp
+++ b/TypeReflection/TypeManager.cpp
@@ -1,0 +1,17 @@
+#include "TypeManager.h"
+
+namespace Type
+{
+	Manager::Manager()
+	{}
+
+	Manager::~Manager()
+	{}
+
+	Manager& Manager::GetHandle()
+	{
+		return TYPE_MANAGER;
+	}
+
+	Manager Manager::TYPE_MANAGER;
+};

--- a/TypeReflection/TypeManager.h
+++ b/TypeReflection/TypeManager.h
@@ -1,0 +1,22 @@
+#ifndef __TYPE_MANAGER_H__
+#define __TYPE_MANAGER_H__
+
+namespace Type
+{
+	class Manager
+	{
+		private :
+			Manager();
+			~Manager();
+
+		public :
+			static Manager& GetHandle();
+
+		private :
+			static Manager TYPE_MANAGER;
+	};
+};
+
+#define GET_TYPE_MANAGER Type::Manager::GetHandle();
+
+#endif // __TYPE_MANAGER_H__

--- a/TypeReflection/TypeUtils.cpp
+++ b/TypeReflection/TypeUtils.cpp
@@ -1,0 +1,49 @@
+#include "TypeUtils.h"
+
+#include <string>
+#include <iostream>
+
+namespace Type
+{
+	namespace Utils
+	{
+		const std::string ConvertToType(const char* _pFuncSignature)
+		{
+			if (_pFuncSignature == nullptr)
+			{
+				return nullptr;
+			}
+
+			static const char* pSpace = " ";
+			static const char* pScope = "::";
+			constexpr size_t spaceLength = 1;
+			constexpr size_t scopeLength = 2;
+
+			std::string strFuncSignature = _pFuncSignature;
+
+			{
+				const size_t position = strFuncSignature.rfind(pScope);
+				if (position == std::string::npos)
+				{
+					return nullptr;
+				}
+
+				strFuncSignature = strFuncSignature.substr(0, position);
+			}
+
+			{
+				size_t position = strFuncSignature.rfind(pSpace);
+				if (position == std::string::npos)
+				{
+					return nullptr;
+				}
+
+				position++;
+
+				strFuncSignature = strFuncSignature.substr(position, strFuncSignature.length() - position);
+			}
+
+			return strFuncSignature;
+		}
+	}
+}

--- a/TypeReflection/TypeUtils.h
+++ b/TypeReflection/TypeUtils.h
@@ -3,6 +3,8 @@
 
 #include "TypeInfo.h"
 
+#include <string>
+
 namespace Type
 {
 	namespace Utils
@@ -31,7 +33,7 @@ namespace Type
 		template<typename T>
 		struct TypeInitializer
 		{
-			static MetaData::TypeInfo Init(const char* className )
+			static MetaData::TypeInfo Init(const std::string& className )
 			{
 				return MetaData::TypeInfo( className, T::GetStaticTypeInfo() );
 			};
@@ -40,7 +42,7 @@ namespace Type
 		template<>
 		struct TypeInitializer<void>
 		{
-			static MetaData::TypeInfo Init(const char* className)
+			static MetaData::TypeInfo Init(const std::string& className)
 			{
 				return MetaData::TypeInfo(className);
 			}
@@ -78,6 +80,8 @@ namespace Type
 
 		template<typename T>
 		using RemovePointer_t = typename RemovePointer<T>::Type;
+
+		const std::string ConvertToType(const char* _pFuncSignature);
 	};
 };
 #endif // __TYPE_UTILS_H__

--- a/demofile/CMakelists.txt
+++ b/demofile/CMakelists.txt
@@ -29,18 +29,18 @@ LIST(APPEND SRCS
     ## Demo file
     ${MAIN_DIR}/main.cpp
 
-    ${CORE_DIR}/Core.h
     ${CORE_DIR}/Platform.h
 
     ${METHODREFLECTION_DIR}/MethodMacro.h
 
     ${PROPERTYREFLECTION_DIR}/PropertyMacro.h
 
-    ${TYPEREFLECTION_DIR}/TypeInfo.h ${TYPEREFLECTION_DIR}/TypeInfo.cpp
-    ${TYPEREFLECTION_DIR}/TypeDetection.h
     ${TYPEREFLECTION_DIR}/TypeMacro.h
     ${TYPEREFLECTION_DIR}/TypeCast.h
-    ${TYPEREFLECTION_DIR}/TypeRemovePointer.h
+    ${TYPEREFLECTION_DIR}/TypeSignature.h
+    ${TYPEREFLECTION_DIR}/TypeUtils.h ${TYPEREFLECTION_DIR}/TypeUtils.cpp
+    ${TYPEREFLECTION_DIR}/TypeInfo.h ${TYPEREFLECTION_DIR}/TypeInfo.cpp
+    ${TYPEREFLECTION_DIR}/TypeManager.h ${TYPEREFLECTION_DIR}/TypeManager.cpp
 )
 
 LIST(APPEND INCS 

--- a/demofile/main.cpp
+++ b/demofile/main.cpp
@@ -27,7 +27,7 @@ namespace Hello
 {
     class NE_API Object : public IObject
     {
-        GENERATE( Hello::Object )
+        GENERATE( Object )
     };
 };
 


### PR DESCRIPTION
[Desc]
- 기존의 TypeReflection에선 객체의 Namespace도 같이 넘겨줘야 했음
- TypeInfo 자체만 사용하기에는 문제가 없지만, TypeManager에 TypeInfo를 넣어서 관리하기에는 이름이 중복되었음
- 그렇기에, 객체 이름 자체가 필요하여서, FUNCSIG 매크로를 통해서 전체 함수 정보를 얻고, 거기서 Namespace + Class 명칭까지 얻는 것으로 변경 [Type/Branch] Feature / Update
[Auther/Data] Winteradio / 2025-02-08

## Type - fix / test / feature / refac / bug / study ## Branch -
## Auther
## Date
## Desc