### PR TITLE
[Title] - Edit the Reflection

### DIFF
--- a/CMakelists.txt
+++ b/CMakelists.txt
@@ -25,6 +25,7 @@ set(INCLUDE_DIR_LIST
 set(HEADER_LIST
     ${HEADER_DIR}/Reflection.h
     ${HEADER_DIR}/Utils.h
+    ${HEADER_DIR}/Macro.h
 
     ${HEADER_DIR}/Method/MethodCall.h
     ${HEADER_DIR}/Method/MethodInfo.h
@@ -42,6 +43,8 @@ set(HEADER_LIST
 )
 
 set(SOURCE_LIST
+    ${SOURCE_DIR}/Utils.cpp
+
     ${SOURCE_DIR}/Method/MethodInfo.cpp
 
     ${SOURCE_DIR}/Property/PropertyInfo.cpp

--- a/include/Macro.h
+++ b/include/Macro.h
@@ -1,0 +1,18 @@
+#ifndef __REFLECTION_MACRO_H__
+#define __REFLECTION_MACRO_H__
+
+#if defined(__GNUC__)
+	#define __CLASSNAME__ __PRETTY_FUNCTION__
+#elif defined(_WIN32)
+	#define __CLASSNAME__ __FUNCSIG__
+#else
+	#define __CLASSNAME__ __func__
+#endif
+
+#if defined(__GNUC__) || defined(__clang__)
+#define __STATIC_USED__ __attribute__((used))
+#else
+#define __STATIC_USED__
+#endif
+
+#endif // __REFLECTION_MACRO_H__

--- a/include/Method/MethodInfo.h
+++ b/include/Method/MethodInfo.h
@@ -48,7 +48,7 @@ namespace Reflection
 				: m_ownerType(initializer.ownerType)
 				, m_methodType(initializer.methodType)
 				, m_methodBase(initializer.methodBase)
-				, m_methodName(methodName)
+				, m_methodName(initializer.ownerType != nullptr ? initializer.ownerType->GetTypeName() + "::" + methodName : methodName)
 			{
 				TypeInfo* ownerType = const_cast<TypeInfo*>(m_ownerType);
 				if (nullptr != ownerType)

--- a/include/Method/MethodMacro.h
+++ b/include/Method/MethodMacro.h
@@ -1,6 +1,7 @@
 #ifndef __REFLECTION_METHODMACRO_H__
 #define __REFLECTION_METHODMACRO_H__
 
+#include "Macro.h"
 #include "Method/MethodInfo.h"
 
 /**
@@ -26,6 +27,6 @@
 			}; \
 		}; \
 		\
-		static inline const RegisterMethod##Method s_registerMethod##Method; \
+		static inline const RegisterMethod##Method s_registerMethod##Method __STATIC_USED__; \
 
 #endif // __REFLECTION_METHODMACRO_H__

--- a/include/Property/ContainerPropertyInfo.h
+++ b/include/Property/ContainerPropertyInfo.h
@@ -398,7 +398,7 @@ namespace Reflection
 	public :
 		const TypeInfo* GetValueType() const { return m_valueType; }
 		const TypeInfo* GetKeyType() const { return m_keyType; }
-		const TypeInfo* GetMappedType() const { return m_keyType; }
+		const TypeInfo* GetMappedType() const { return m_mappedType; }
 
 		const void* GetRawKey(const void* rawValue) const
 		{

--- a/include/Property/PropertyInfo.h
+++ b/include/Property/PropertyInfo.h
@@ -64,7 +64,7 @@ namespace Reflection
 			 */
 			template<typename Type, typename Property>
 			explicit PropertyInfo(const Initializer<Type, Property>& initializer, const std::string& propertyName)
-				: m_propertyName(propertyName)
+				: m_propertyName(initializer.ownerType != nullptr ? initializer.ownerType->GetTypeName() + "::" + propertyName : propertyName)
 				, m_propertyOffset(initializer.propertyOffset)
 				, m_propertyType(initializer.propertyType)
 				, m_ownerType(initializer.ownerType)

--- a/include/Property/PropertyMacro.h
+++ b/include/Property/PropertyMacro.h
@@ -1,6 +1,7 @@
 #ifndef __REFLECTION_PROPERTYMACRO_H__
 #define __REFLECTION_PROPERTYMACRO_H__
 
+#include "Macro.h"
 #include "Property/PropertyInfo.h"
 #include "Property/PropertyCreator.h"
 
@@ -28,6 +29,6 @@
 			}; \
 		}; \
 		\
-		static inline const RegisterProperty##Property s_registerProperty##Property; \
+		static inline const RegisterProperty##Property s_registerProperty##Property __STATIC_USED__; \
 
 #endif // __REFLECTION_PROPERTYMACRO_H__

--- a/include/Type/TypeMacro.h
+++ b/include/Type/TypeMacro.h
@@ -1,6 +1,7 @@
 #ifndef __REFLECTION_TYPEMACRO_H__
 #define __REFLECTION_TYPEMACRO_H__
 
+#include "Macro.h"
 #include "Type/TypeInfo.h"
 
 /**
@@ -36,6 +37,6 @@
 		} \
 \
 	private : \
-		static inline const Reflection::TypeInfo* s_typeInfo = GetStaticTypeInfo(); \
+		static inline const Reflection::TypeInfo* s_typeInfo __STATIC_USED__ = GetStaticTypeInfo();\
 
 #endif // __REFLECTIONTYPE_MACRO_H__

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -420,6 +420,20 @@ namespace Reflection
 			using ClassType = Class;
 			using PropertyType = Property;
 		};
+
+		template<typename T, typename = void>
+		struct HasRuntimeType
+		{
+			static constexpr bool value = false;
+		};
+
+		template<typename T>
+		struct HasRuntimeType<T, typename Reflection::Utils::TypeWrapper<decltype(std::declval<T>().GetTypeInfo())>::Type>
+		{
+			static constexpr bool value = true;
+		};
+		
+		const std::string GetName(const std::string& rawClassName);
 	};
 };
 #endif // __REFLECTION_UTILS_H__

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,74 @@
+#include "Utils.h"
+#include <algorithm>
+
+namespace Reflection
+{
+	namespace Utils
+	{
+#if defined(_WIN32)
+		const std::string GetName(const std::string& rawClassName)
+		{
+			std::string className;
+			
+			static const std::string first = "<";
+			static const std::string last = ">(void)";
+			static const std::string strClass = "class";
+			static const std::string strStruct = "struct";
+			
+			const size_t firstPos = rawClassName.find(first) + first.size();
+			const size_t lastPos = rawClassName.find(last);
+			
+			if (firstPos == std::string::npos || lastPos == std::string::npos)
+			{
+				return "";
+			}
+			
+			className = rawClassName.substr(firstPos, lastPos - firstPos);
+			
+			while (true)
+			{
+				const size_t classPos = className.find(strClass);
+				if (classPos == std::string::npos)
+				{
+					break;
+				}
+				
+				className.erase(classPos, strClass.length());
+			}
+			
+			while (true)
+			{
+				const size_t structPos = className.find(strStruct);
+				if (structPos == std::string::npos)
+				{
+					break;
+				}
+				
+				className.erase(structPos, strStruct.length());
+			}
+			
+			return className;
+		}
+#else
+		const std::string GetClassName(const std::string& rawClassName)
+		{
+			std::string className;
+			
+			static const std::string first = "[with T = ";
+			static const std::string last = "]";
+			
+			const size_t firstPos = rawClassName.find(first) + first.size();
+			const size_t lastPos = rawClassName.find(last);
+			
+			if (firstPos == std::string::npos || lastPos == std::string::npos)
+			{
+				return "";
+			}
+			
+			className = rawClassName.substr(firstPos, lastPos - firstPos);
+			
+			return className;
+		}
+#endif
+	}
+}


### PR DESCRIPTION
[Desc]
 - ** Fix ** the dead code elimination was occured in the gcc compiler on the template class that used the property and method macro. Add the "used" macro keyword in the property and method's static variable that make the property info and method info. But, this solution is not perfect, so, needs to find the right solution.
 - Add the Getter the property and method info from the super type. So, if the properties and methods are same as super's things, the hash(used the object's name) will be same and fail to add the type info. So, Add the class name function in the utils file. The file helps the type info get the real name and the property and method add the keyword that is the type name in front of the their name.
 - Fix the container property info's getter function for the mapped type. (m_keyType -> m_mappedType) [Type/Branch]
[Auther/Data]